### PR TITLE
small change to prune function

### DIFF
--- a/src/commands/moderation/prune.js
+++ b/src/commands/moderation/prune.js
@@ -3,7 +3,7 @@ exports.run = async (bot, msg, args) => {
     if (Number.isNaN(args[0])) throw new Error('Your amount isn\'t a number.');
     if (args[0] > 50) throw new Error('You can\'t delete more that 50 messages at once');
 
-    const messages = await msg.channel.fetchMessages({ limit: Number(args[0]) });
+    const messages = await msg.channel.fetchMessages({ limit: Number(args[0])+1 });
 
     for (const msgToDelete of messages.values()) {
         if (msgToDelete.deletable) {

--- a/src/commands/moderation/prune.js
+++ b/src/commands/moderation/prune.js
@@ -3,7 +3,7 @@ exports.run = async (bot, msg, args) => {
     if (Number.isNaN(args[0])) throw new Error('Your amount isn\'t a number.');
     if (args[0] > 50) throw new Error('You can\'t delete more that 50 messages at once');
 
-    const messages = await msg.channel.fetchMessages({ limit: Number(args[0])+1 });
+    const messages = await msg.channel.fetchMessages({ limit: Number(args[0]) + 1 });
 
     for (const msgToDelete of messages.values()) {
         if (msgToDelete.deletable) {


### PR DESCRIPTION
I think this should be added because the prune function will also delete `tr!prune` command and if you say `tr!prune 5` it will delete 4 messages and the command but if we add this in then it will delete 5 messages and the command. It just makes more sense to me.